### PR TITLE
fix: resolve chained ->not property access error (issue #2)

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -10,6 +10,11 @@ services:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
+        class: PestStan\Type\Pest\OppositeExpectationMethodReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
         class: PestStan\Type\Pest\TestClosureThisTypeExtension
         tags:
             - phpstan.functionParameterClosureThisExtension

--- a/src/Type/Pest/OppositeExpectationMethodReturnTypeExtension.php
+++ b/src/Type/Pest/OppositeExpectationMethodReturnTypeExtension.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PestStan\Type\Pest;
+
+use Pest\Expectation;
+use Pest\Expectations\OppositeExpectation;
+use Pest\Mixins\Expectation as MixinsExpectation;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Type;
+
+/**
+ * Fixes return types for assertion methods on Pest\Expectations\OppositeExpectation,
+ * ensuring chained ->not accesses resolve to Pest\Expectation<TValue> instead of
+ * Pest\Mixins\Expectation<mixed>.
+ */
+final class OppositeExpectationMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return OppositeExpectation::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getDeclaringClass()->getName() === MixinsExpectation::class;
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
+        $valueType = $scope->getType($methodCall->var)
+            ->getTemplateType(OppositeExpectation::class, 'TValue');
+
+        return new GenericObjectType(Expectation::class, [$valueType]);
+    }
+}

--- a/tests/Type/data/expectation-methods.php
+++ b/tests/Type/data/expectation-methods.php
@@ -246,3 +246,15 @@ function testToBeListNarrows(): void
     $result = expect($value)->toBeList();
     assertType('Pest\Expectation<list>', $result);
 }
+
+function testChainedNot(): void
+{
+    $result = expect(1)->not->toBe(2)->not->toBe(3);
+    assertType('Pest\Expectation<mixed>', $result);
+}
+
+function testChainedNotWithMethod(): void
+{
+    $result = expect(1)->not()->toBe(2)->not()->toBe(3);
+    assertType('Pest\Expectation<1>', $result);
+}


### PR DESCRIPTION
When assertion methods like toBe() are called on OppositeExpectation (e.g. expect(1)->not->toBe(2)), PHPStan resolved the return type as Pest\Mixins\Expectation<mixed> via the @mixin chain. Since Mixins\Expectation does not carry the \ @property, a subsequent ->not access would fail with:

  Access to an undefined property Pest\Mixins\Expectation::\.

Fix: add OppositeExpectationMethodReturnTypeExtension, a DynamicMethodReturnType Extension registered for OppositeExpectation that intercepts mixin method calls and returns Pest\Expectation<TValue> instead.