### PR TITLE
Feat: something new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### What's Changed
-
-* feat: expose public methods from a configured custom `testCaseClass` on `TestCall` chains
-* feat: explicitly type additional Pest global helpers in `PestFunctionReturnTypeExtension`
-* fix: validate every variadic symbol passed to `coversClass()`, `coversTrait()`, and `coversFunction()`
-* fix: treat `todo()` as a valid test definition inside `describe()` blocks
-* docs: remove README entries for rules that are no longer shipped
-* docs: sync helper-return and extension architecture docs with the shipped code
-
 ## 0.2.7 - 2026-04-26
 
 **Full Changelog**: https://github.com/MrPunyapal/PestStan/compare/0.2.6...0.2.7
@@ -122,4 +111,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Auto-detect TestCase & dynamic TestCase property support by @MrPunyapal in https://github.com/MrPunyapal/PestStan/pull/4
 
 **Full Changelog**: https://github.com/MrPunyapal/PestStan/compare/0.0.3...0.1.0
+
+## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### What's Changed
 
 * feat: expose public methods from a configured custom `testCaseClass` on `TestCall` chains
+* feat: explicitly type additional Pest global helpers in `PestFunctionReturnTypeExtension`
+* fix: validate every variadic symbol passed to `coversClass()`, `coversTrait()`, and `coversFunction()`
+* fix: treat `todo()` as a valid test definition inside `describe()` blocks
 * docs: remove README entries for rules that are no longer shipped
+* docs: sync helper-return and extension architecture docs with the shipped code
 
 ## 0.2.7 - 2026-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### What's Changed
+
+* feat: expose public methods from a configured custom `testCaseClass` on `TestCall` chains
+* docs: remove README entries for rules that are no longer shipped
+
 ## 0.2.7 - 2026-04-26
 
 **Full Changelog**: https://github.com/MrPunyapal/PestStan/compare/0.2.6...0.2.7
@@ -112,4 +119,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full Changelog**: https://github.com/MrPunyapal/PestStan/compare/0.0.3...0.1.0
 
-## [Unreleased]

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,11 +34,12 @@ composer test:unit     # Run Pest tests
 ```
 PestStan/
 ├── src/Type/Pest/
-│   ├── PestFunctionReturnTypeExtension.php            # expect/it/test/todo/describe return types
+│   ├── PestFunctionReturnTypeExtension.php            # Pest global helper return types
 │   ├── ExpectationMethodReturnTypeExtension.php       # Type narrowing for assertion methods
 │   ├── OppositeExpectationMethodReturnTypeExtension.php # not() return types
 │   ├── TestClosureThisTypeExtension.php               # $this binding in closures
 │   ├── PestConfigReader.php                           # Pest.php auto-detection for TestCase
+│   ├── TestCallMethodsClassReflectionExtension.php    # TestCall fluent methods from Pest mixins and custom testCaseClass
 │   ├── TestCasePropertiesExtension.php                # Dynamic property support
 │   └── PestTestCaseProperty.php                       # PropertyReflection for dynamic props
 ├── tests/
@@ -50,7 +51,7 @@ PestStan/
 │       ├── ExpectTypeTest.php                         # Main test runner
 │       ├── CustomTestCaseTest.php                     # Custom TestCase test runner
 │       ├── Fixtures/
-│       │   └── CustomTestCase.php                     # Test fixture
+│       │   └── CustomTestCase.php                     # Custom test case fixture for $this and TestCall method coverage
 │       ├── custom-testcase-extension.neon             # PHPStan config for custom TestCase tests
 │       └── data/
 │           ├── expect-function.php                    # expect() return type tests
@@ -58,7 +59,7 @@ PestStan/
 │           ├── test-closures.php                      # $this binding + dynamic property tests
 │           ├── test-closures-custom-testcase.php      # Custom TestCase $this binding tests
 │           ├── test-call-methods.php                  # TestCall chaining tests
-│           ├── pest-functions.php                     # Pest function return type tests
+│           ├── pest-functions.php                     # Pest global helper return type tests
 │           └── arch-expectations.php                  # Architecture testing type tests
 ├── extension.neon                                     # PHPStan extension config
 ├── composer.json
@@ -74,11 +75,15 @@ All type information is provided through PHPStan dynamic type extensions (no stu
 
 ### 1. PestFunctionReturnTypeExtension
 
-`DynamicFunctionReturnTypeExtension` that overrides return types for Pest global functions:
+`DynamicFunctionReturnTypeExtension` that overrides return types for Pest global helpers:
 
 - `expect($value)` → `Expectation<typeof $value>` (removes `|null` from Pest's phpdoc)
+- `pest()` → `Configuration`
+- `uses(...)` → `UsesCall`
 - `it()` / `test()` / `todo()` → `TestCall`
 - `describe()` → `DescribeCall`
+- `beforeEach()` / `afterEach()` → pending call wrappers
+- `beforeAll()` / `afterAll()` / `dataset()` / `covers()` / `mutates()` → `null`
 
 ### 2. ExpectationMethodReturnTypeExtension
 
@@ -108,6 +113,14 @@ Requires `universalObjectCratesClasses` for `PHPUnit\Framework\TestCase` (set au
 ### 6. Configuration (`extension.neon`)
 
 Registers all extensions with PHPStan. Configures `universalObjectCratesClasses` for dynamic property support and `ignoreErrors` for Pest's `@internal` class annotations. Auto-loaded via `phpstan/extension-installer` or manually included.
+
+### 7. TestCallMethodsClassReflectionExtension
+
+`MethodsClassReflectionExtension` that exposes fluent `TestCall` methods coming from Pest mixins and the configured custom `peststan.testCaseClass`.
+
+- Resolves methods from `Pest\Concerns\Testable` and `Pest\Support\HigherOrderCallables`
+- Adds public methods from a custom `testCaseClass` when it differs from `PHPUnit\Framework\TestCase`
+- Skips native `TestCall` methods so custom helpers do not shadow real API methods
 
 ## Testing Approach
 

--- a/README.md
+++ b/README.md
@@ -173,8 +173,14 @@ Accurate return types for all Pest global functions:
 | Function | Return Type |
 |----------|-------------|
 | `expect($value)` | `Expectation<TValue>` |
+| `pest()` | `Configuration` |
+| `uses(...)` | `UsesCall` |
 | `it()` / `test()` / `todo()` | `TestCall` |
 | `describe()` | `DescribeCall` |
+| `beforeEach()` | `BeforeEachCall` |
+| `afterEach()` | `AfterEachCall` |
+| `beforeAll()` / `afterAll()` | `null` |
+| `dataset()` / `covers()` / `mutates()` | `null` |
 
 ### `not()` and `each()` Return Types
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ it('does something', function () { /* ... */ })
     ->repeat(3);
 ```
 
+When you set `peststan.testCaseClass` to a custom class, PestStan also exposes that class's public helper methods on `TestCall` chains:
+
+```php
+it('uses a custom helper')->publicHelper();
+```
+
 ### Architecture Testing Support
 
 Architecture testing methods are fully supported:
@@ -330,34 +336,6 @@ beforeAll(function () {
 ```
 
 Use `beforeEach()` to run setup before each test with `$this` available.
-
-### `pest.todoWithClosure` — `->todo()` with a closure body
-
-`->todo()` marks a test as pending and the closure is **never executed** — any code inside the closure is dead code.
-
-```php
-it('should validate email', function () {
-    expect(validateEmail('test@example.com'))->toBeTrue();
-})->todo();
-// ✘ Test 'should validate email' is marked as todo() but still has a closure body — the code will not execute.
-```
-
-Options:
-- Remove the closure body: `it('should validate email')->todo()` — pure pending placeholder.
-- Use `->skip()` to preserve the code but skip execution.
-- Remove `->todo()` to make the test run.
-
-### `pest.missingAssertion` — Test with no assertions
-
-A test closure that neither calls `expect()` nor any `assert*()` method provides no safety guarantees.
-
-```php
-it('processes the order', function () {
-    $order = Order::create(['total' => 100]);
-    $order->process();
-    // ✘ Test 'processes the order' has no assertions. Did you forget expect()?
-});
-```
 
 ### `pest.throwsClassNotFound` / `pest.invalidThrowsException` — Invalid `throws()` argument
 

--- a/extension.neon
+++ b/extension.neon
@@ -77,6 +77,8 @@ services:
 
     -
         class: PestStan\Type\Pest\TestCallMethodsClassReflectionExtension
+        arguments:
+            testCaseClass: %peststan.testCaseClass%
         tags:
             - phpstan.broker.methodsClassReflectionExtension
 

--- a/src/PestFunctionDetector.php
+++ b/src/PestFunctionDetector.php
@@ -15,8 +15,20 @@ use PhpParser\Node\Scalar\String_;
  */
 final class PestFunctionDetector
 {
-    /** @var array<string, int> Maps function names to the expected closure argument index */
+    /** @var list<string> */
     private const ALL_FUNCTIONS = [
+        'it',
+        'test',
+        'todo',
+        'describe',
+        'beforeEach',
+        'afterEach',
+        'beforeAll',
+        'afterAll',
+    ];
+
+    /** @var array<string, int> Maps function names to the expected closure argument index */
+    private const CLOSURE_FUNCTIONS = [
         'it' => 1,
         'test' => 1,
         'describe' => 1,
@@ -27,7 +39,7 @@ final class PestFunctionDetector
     ];
 
     /** @var list<string> */
-    private const TEST_FUNCTIONS = ['it', 'test'];
+    private const TEST_FUNCTIONS = ['it', 'test', 'todo'];
 
     /** @var list<string> */
     private const HOOK_FUNCTIONS = ['beforeEach', 'afterEach', 'beforeAll', 'afterAll'];
@@ -40,7 +52,7 @@ final class PestFunctionDetector
 
         $name = $node->name->toString();
 
-        return isset(self::ALL_FUNCTIONS[$name]) ? $name : null;
+        return in_array($name, self::ALL_FUNCTIONS, true) ? $name : null;
     }
 
     public static function isPestFunction(FuncCall $node): bool
@@ -69,7 +81,7 @@ final class PestFunctionDetector
 
     public static function getClosureArgIndex(string $functionName): ?int
     {
-        return self::ALL_FUNCTIONS[$functionName] ?? null;
+        return self::CLOSURE_FUNCTIONS[$functionName] ?? null;
     }
 
     public static function extractClosure(FuncCall $node): Closure|ArrowFunction|null
@@ -79,7 +91,11 @@ final class PestFunctionDetector
             return null;
         }
 
-        $closureArgIndex = self::ALL_FUNCTIONS[$name];
+        $closureArgIndex = self::getClosureArgIndex($name);
+        if ($closureArgIndex === null) {
+            return null;
+        }
+
         $args = $node->getArgs();
 
         if (! isset($args[$closureArgIndex])) {

--- a/src/Rules/CoversClassExistsRule.php
+++ b/src/Rules/CoversClassExistsRule.php
@@ -66,38 +66,37 @@ final class CoversClassExistsRule implements Rule
             return [];
         }
 
-        $symbolName = $this->extractClassName($args[0]->value);
-        if ($symbolName === null) {
-            return [];
-        }
-
         $symbolType = self::COVERS_METHODS[$methodName];
+        $errors = [];
 
-        if ($symbolType === 'Function') {
-            if (! $this->reflectionProvider->hasFunction(new Name($symbolName), null)) {
-                return [
-                    RuleErrorBuilder::message(
+        foreach ($args as $arg) {
+            $symbolName = $this->extractClassName($arg->value);
+            if ($symbolName === null) {
+                continue;
+            }
+
+            if ($symbolType === 'Function') {
+                if (! $this->reflectionProvider->hasFunction(new Name($symbolName), null)) {
+                    $errors[] = RuleErrorBuilder::message(
                         sprintf('Function %s() referenced in %s() does not exist.', $symbolName, $methodName)
                     )
                         ->identifier('pest.coversFunctionNotFound')
-                        ->build(),
-                ];
+                        ->build();
+                }
+
+                continue;
             }
 
-            return [];
-        }
-
-        if (! $this->reflectionProvider->hasClass($symbolName)) {
-            return [
-                RuleErrorBuilder::message(
+            if (! $this->reflectionProvider->hasClass($symbolName)) {
+                $errors[] = RuleErrorBuilder::message(
                     sprintf('%s %s referenced in %s() does not exist.', $symbolType, $symbolName, $methodName)
                 )
                     ->identifier('pest.coversClassNotFound')
-                    ->build(),
-            ];
+                    ->build();
+            }
         }
 
-        return [];
+        return $errors;
     }
 
     private function extractClassName(Expr $expr): ?string

--- a/src/Type/Pest/PestFunctionReturnTypeExtension.php
+++ b/src/Type/Pest/PestFunctionReturnTypeExtension.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace PestStan\Type\Pest;
 
+use Pest\Configuration;
 use Pest\Expectation;
+use Pest\PendingCalls\AfterEachCall;
+use Pest\PendingCalls\BeforeEachCall;
 use Pest\PendingCalls\DescribeCall;
 use Pest\PendingCalls\TestCall;
+use Pest\PendingCalls\UsesCall;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
@@ -23,17 +27,32 @@ final class PestFunctionReturnTypeExtension implements DynamicFunctionReturnType
 {
     /** @var array<string, class-string> Maps function names to return class names */
     private const FUNCTION_RETURN_TYPES = [
+        'pest' => Configuration::class,
+        'uses' => UsesCall::class,
         'it' => TestCall::class,
         'test' => TestCall::class,
         'todo' => TestCall::class,
         'describe' => DescribeCall::class,
+        'beforeEach' => BeforeEachCall::class,
+        'afterEach' => AfterEachCall::class,
+    ];
+
+    /** @var list<string> */
+    private const NULL_RETURN_TYPES = [
+        'beforeAll',
+        'afterAll',
+        'dataset',
+        'covers',
+        'mutates',
     ];
 
     public function isFunctionSupported(FunctionReflection $functionReflection): bool
     {
         $name = $functionReflection->getName();
 
-        return $name === 'expect' || isset(self::FUNCTION_RETURN_TYPES[$name]);
+        return $name === 'expect'
+            || isset(self::FUNCTION_RETURN_TYPES[$name])
+            || in_array($name, self::NULL_RETURN_TYPES, true);
     }
 
     public function getTypeFromFunctionCall(
@@ -45,6 +64,10 @@ final class PestFunctionReturnTypeExtension implements DynamicFunctionReturnType
 
         if ($name === 'expect') {
             return $this->resolveExpect($functionCall, $scope);
+        }
+
+        if (in_array($name, self::NULL_RETURN_TYPES, true)) {
+            return new NullType;
         }
 
         return new ObjectType(self::FUNCTION_RETURN_TYPES[$name]);

--- a/src/Type/Pest/TestCallMethodsClassReflectionExtension.php
+++ b/src/Type/Pest/TestCallMethodsClassReflectionExtension.php
@@ -12,6 +12,7 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Resolves methods on TestCall that originate from its @mixin types.
@@ -32,8 +33,10 @@ final class TestCallMethodsClassReflectionExtension implements MethodsClassRefle
         HigherOrderCallables::class,
     ];
 
+    /** @param class-string $testCaseClass */
     public function __construct(
         private readonly ReflectionProvider $reflectionProvider,
+        private readonly string $testCaseClass = TestCase::class,
     ) {}
 
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
@@ -46,11 +49,8 @@ final class TestCallMethodsClassReflectionExtension implements MethodsClassRefle
             return false;
         }
 
-        foreach (self::MIXIN_CLASSES as $mixinClass) {
-            if (
-                $this->reflectionProvider->hasClass($mixinClass)
-                && $this->reflectionProvider->getClass($mixinClass)->hasNativeMethod($methodName)
-            ) {
+        foreach ($this->mixinClasses() as $mixinClass) {
+            if ($this->hasPublicMixinMethod($mixinClass, $methodName)) {
                 return true;
             }
         }
@@ -60,18 +60,36 @@ final class TestCallMethodsClassReflectionExtension implements MethodsClassRefle
 
     public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
     {
-        foreach (self::MIXIN_CLASSES as $mixinClass) {
-            if (! $this->reflectionProvider->hasClass($mixinClass)) {
-                continue;
-            }
-
-            $mixinReflection = $this->reflectionProvider->getClass($mixinClass);
-
-            if ($mixinReflection->hasNativeMethod($methodName)) {
-                return $mixinReflection->getNativeMethod($methodName);
+        foreach ($this->mixinClasses() as $mixinClass) {
+            if ($this->hasPublicMixinMethod($mixinClass, $methodName)) {
+                return $this->reflectionProvider->getClass($mixinClass)->getNativeMethod($methodName);
             }
         }
 
         throw new LogicException(sprintf('Method %s not found on any TestCall mixin class.', $methodName));
+    }
+
+    /** @return list<class-string> */
+    private function mixinClasses(): array
+    {
+        if ($this->testCaseClass === TestCase::class) {
+            return self::MIXIN_CLASSES;
+        }
+
+        return [...self::MIXIN_CLASSES, $this->testCaseClass];
+    }
+
+    private function hasPublicMixinMethod(string $mixinClass, string $methodName): bool
+    {
+        if (! $this->reflectionProvider->hasClass($mixinClass)) {
+            return false;
+        }
+
+        $mixinReflection = $this->reflectionProvider->getClass($mixinClass);
+        if (! $mixinReflection->hasNativeMethod($methodName)) {
+            return false;
+        }
+
+        return $mixinReflection->getNativeMethod($methodName)->isPublic();
     }
 }

--- a/tests/Type/CoversClassExistsRuleTest.php
+++ b/tests/Type/CoversClassExistsRuleTest.php
@@ -35,6 +35,14 @@ class CoversClassExistsRuleTest extends RuleTestCase
                 'Class App\NonExistent\FakeClass referenced in coversClass() does not exist.',
                 8,
             ],
+            [
+                'Class App\NonExistent\SecondFakeClass referenced in coversClass() does not exist.',
+                18,
+            ],
+            [
+                'Function missing_test_helper() referenced in coversFunction() does not exist.',
+                23,
+            ],
         ]);
     }
 }

--- a/tests/Type/Fixtures/CustomTestCase.php
+++ b/tests/Type/Fixtures/CustomTestCase.php
@@ -8,6 +8,11 @@ use PHPUnit\Framework\TestCase;
 
 class CustomTestCase extends TestCase
 {
+    public function publicHelper(): string
+    {
+        return 'helper';
+    }
+
     protected function createHelper(): string
     {
         return 'helper';

--- a/tests/Type/data/covers-class-exists.php
+++ b/tests/Type/data/covers-class-exists.php
@@ -13,3 +13,13 @@ it('covers non-existent', function (): void {
 it('covers existing', function (): void {
     expect(true)->toBeTrue();
 })->coversClass(Post::class);
+
+// Errors: coversClass with invalid second argument
+it('covers mixed class list', function (): void {
+    expect(true)->toBeTrue();
+})->coversClass(Post::class, 'App\\NonExistent\\SecondFakeClass'); // line 18
+
+// Errors: coversFunction with invalid second argument
+it('covers mixed functions', function (): void {
+    expect(true)->toBeTrue();
+})->coversFunction('strlen', 'missing_test_helper'); // line 23

--- a/tests/Type/data/describe-without-tests.php
+++ b/tests/Type/data/describe-without-tests.php
@@ -45,5 +45,5 @@ describe('test something', function () {
 
 // valid: describe with todo test
 describe('todo test', function (): void {
-    it('todo', function (): void {});
+    todo('todo');
 });

--- a/tests/Type/data/pest-functions.php
+++ b/tests/Type/data/pest-functions.php
@@ -55,3 +55,18 @@ function testAfterAllReturnType(): void
 {
     assertType('null', afterAll(function (): void {}));
 }
+
+function testDatasetReturnType(): void
+{
+    assertType('null', dataset('numbers', [1, 2, 3]));
+}
+
+function testCoversReturnType(): void
+{
+    assertType('null', covers(TestCase::class));
+}
+
+function testMutatesReturnType(): void
+{
+    assertType('null', mutates(TestCase::class));
+}

--- a/tests/Type/data/test-closures-custom-testcase.php
+++ b/tests/Type/data/test-closures-custom-testcase.php
@@ -49,3 +49,8 @@ function testProtectedMethodCallFromParentOnCustomTestCase(): void
         assertType('string', $this->getActualOutputForAssertion());
     });
 }
+
+function testTestCallMethodOnCustomTestCase(): void
+{
+    assertType('string', it('uses custom test case fluent methods')->publicHelper());
+}


### PR DESCRIPTION
## Summary

This PR improves PestStan in a few practical places without changing how users configure it.

## Practical Impact

- Custom Pest test case helper methods now work better in fluent `TestCall` chains, so PHPStan understands more of the code users already write.
- More Pest helper functions now resolve to the right types, which reduces mixed or missing-type analysis issues.
- Coverage validation is stricter in the right way: if multiple symbols are passed to `coversClass()`, `coversTrait()`, or `coversFunction()`, every one of them is checked.
- `describe()` blocks that contain `todo()` tests are no longer treated like empty groups.
- Documentation now reflects the actual shipped behavior.

## Problem Solved

- Users get fewer false positives and fewer missing-analysis gaps in normal Pest usage.
- Invalid coverage references are less likely to slip through unnoticed.
- Teams using custom Pest test cases get better support without extra setup.
- The package behavior and the docs now match.